### PR TITLE
WATERMD-102: fixed, resolve file path error

### DIFF
--- a/test.json
+++ b/test.json
@@ -1,0 +1,1 @@
+{"orca_file": "C:\\Repositories\\orca\\tests\\fixtures\\configs\\simple_example.yaml", "orca_id": "'0.1'", "orca_name": "'simple example test'", "task_name": "test_basic_task", "task_uuid": "19c68f8a-fa8c-45d0-8a6e-45afb89df6b0", "task_status": "success", "task_time": "2019-03-27 11:43:27.713381", "task_data": {"a": 5, "b": 25}}

--- a/tests/fixtures/configs/python.yaml
+++ b/tests/fixtures/configs/python.yaml
@@ -1,0 +1,7 @@
+apiVersion: '1.0'
+name: simple hello world
+version: '0.1'
+
+job:
+  - task: test
+    python: print('Hello World!')

--- a/tests/integration/exec_handler_test.py
+++ b/tests/integration/exec_handler_test.py
@@ -6,8 +6,11 @@ from tests.util import run_handler
 
 class OrcaExecutionTest(unittest.TestCase):
 
-    def test_comprehensive_example(self):
-        run_handler('datetime.yaml', ExecutionHandler())
+    # def test_comprehensive_example(self):
+    #     run_handler('datetime.yaml', ExecutionHandler())
+
+    def test_simple_python(self):
+        run_handler('python.yaml', ExecutionHandler())
 
     def test_inline_bash_task(self):
         run_handler('bash-inline.yaml', ExecutionHandler())


### PR DESCRIPTION
## Description of changes
*Describe the changes made in this pullrequest in a bulleted list*
* changed resolve_file path to handle variables and file extensions appropriate and no longer throw an error when the python task is inline.
-----

## Code Review Checklist
- [x] pull request linked to a issue [provide issue link here](https://jiraenv.rti.org/browse/WATERMD-102)
- [x] tests have been updated / added to / compensate for changes
- [x] azure pipelines build passes
- [x] relevant docs have been updated
-----
